### PR TITLE
using ScrollToTop to return to top on route change

### DIFF
--- a/src/helpers/ScrollToTop.js
+++ b/src/helpers/ScrollToTop.js
@@ -1,0 +1,19 @@
+// ScrollToTop.js by zurfyx, from https://stackoverflow.com/questions/36904185/react-router-scroll-to-top-on-every-transition
+
+import React, { useEffect, Fragment } from 'react';
+import { withRouter } from 'react-router-dom';
+
+function ScrollToTop({ history, children }) {
+  useEffect(() => {
+    const unlisten = history.listen(() => {
+      window.scrollTo(0, 0);
+    });
+    return () => {
+      unlisten();
+    }
+  }, []);
+
+  return <Fragment>{children}</Fragment>;
+}
+
+export default withRouter(ScrollToTop);

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,15 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { CookiesProvider } from 'react-cookie';
+import ScrollToTop from './helpers/ScrollToTop';
 
 ReactDOM.render(
 	<CookiesProvider>
 		<Router>
-			<App />
+      <ScrollToTop>
+		  	<App />
+      </ScrollToTop>
 		</Router>
-		,
 	</CookiesProvider>,
 	document.getElementById('root')
 );


### PR DESCRIPTION
Now when you change views the page will scroll back up, to better simulate loading a new page

Used solution from https://stackoverflow.com/questions/36904185/react-router-scroll-to-top-on-every-transition